### PR TITLE
Add CODEOWNERS for DevTech team

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,9 @@
 
 ## Ignore all dotfiles
 .*
-## except for .gitignore
+## except for .gitignore and .gitlab-ci.yml
 !.gitignore
+!.gitlab-ci.yml
 
 ## SBT
 target

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,14 @@
+stages:
+  - compile
+
+variables:
+  PROJECT_NAME: algorithmia-scala
+  DOCKER_HOST: tcp://docker:2375/
+  DOCKER_DRIVER: overlay2
+  RUNNING_ON_BUILD_SERVER: "true"
+
+compile:compile:
+  stage: compile
+  image: algorithmiahq/sbt-builder:11.0.6_1.3.8_2.13.1
+  script:
+  - sbt compile

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# https://github.blog/2017-07-06-introducing-code-owners/
+
+*   @algorithmiaio/developer-technologies-contractors


### PR DESCRIPTION
DevTech team is now the code owner of the repository; all changes will be authored (or at least approved) by them.

Also added a CI build to verify that the code compiles successfully. The unit tests cannot currently be run in CI because they rely on an API key for the public marketplace; we can enable that in a follow-on PR. This is at least an improvement over what existed before (zero CI verification of compilability)